### PR TITLE
Update ssh-ip-blinker to work with 3-digit octets

### DIFF
--- a/payloads/library/util/ssh-ip-blinker/payload.sh
+++ b/payloads/library/util/ssh-ip-blinker/payload.sh
@@ -2,7 +2,7 @@
 #
 # Title:        SSH IP Blinker
 # Author:       Hak5Darren
-# Version:      1.0
+# Version:      1.1
 #
 # Description:	This payload makes it easier to develop payloads which require Internet access.
 # This is useful for installing packages via opkg, or testing payloads in development.
@@ -14,9 +14,12 @@
 # four times, pause, then blink twice. This indicates that the last octet of its IP address is
 # .42 - so if your home LAN is 192.168.1.0, then your Shark Jack should be found at 192.168.1.42
 #
+# If one of the octets is zero this will be represented as solid for 1 second.
+#
 # Magenta...........Setup
 # Red Slow Blink....Failed to obtain IP address
-# Cyan Fast Blinks..Last octet of IPv4 address
+# Cyan Fast Blink...A non-zero digit of last octet
+# Cyan Solid........A zero digit of last octet
 
 LED SETUP
 # Set NETMODE to DHCP_CLIENT for Shark Jack v1.1.0+
@@ -28,55 +31,28 @@ while ! ifconfig eth0 | grep "inet addr"; do sleep 1; done
 sleep 10
 LASTOCTET=$(ifconfig eth0 | grep "inet addr" | awk {'print $2'} | awk -F. {'print $4'})
 LED OFF
-LO1=${LASTOCTET:0:1}
-LO2=${LASTOCTET:1:2}
-LO3=${LASTOCTET:2:3}
+
+if [ -z "$LASTOCTET" ]; then
+	LED FAIL
+	exit
+fi
 
 while true; do
+	for (( i = 0; i < ${#LASTOCTET}; i++ )); do
+		DIGIT=${LASTOCTET:$i:1}
 
-if [ -z "$LO1" ]
-then
-	LED FAIL
-	exit 
-else
-	sleep 1
-	i=0
-	while [ $i -lt $LO1 ]
-	do
-		LED C SOLID; sleep 0.05
-		LED OFF; sleep 0.125
-		i=$(( $i + 1 ))
-	done 
-fi
+		if [ $DIGIT = "0" ]; then
+			LED C SOLID; sleep 1
+			LED OFF; sleep 0.125
+		else
+			for (( j = 0; j < $DIGIT; j++ )); do
+				LED C SOLID; sleep 0.05
+				LED OFF; sleep 0.125
+			done
+		fi
 
-if [ -z "$LO2" ]
-then
-	sleep 1
-else
-        sleep 1
-        i=0                     
-        while [ $i -lt $LO2 ]
-        do                            
-                LED C SOLID; sleep 0.05
-                LED OFF; sleep 0.125
-                i=$(( $i + 1 ))
-        done
-fi
+		sleep 1
+	done
 
-if [ -z "$LO3" ]
-then
-	sleep 1
-else
-        sleep 1
-        i=0                     
-        while [ $i -lt $LO3 ]
-        do                            
-                LED C SOLID; sleep 0.05
-                LED OFF; sleep 0.125
-                i=$(( $i + 1 ))
-        done
-fi
-
-sleep 2
-
+	sleep 2
 done


### PR DESCRIPTION
This PR fixes a small issue with ssh-ip-blinker that stopped it from working if the IP assigned to it ended in a 3-digit octet.

Upon connection my jack was given an IP of 250 which I was surprised to find out was represented as 2 blinks and 50 blinks.

The issue lies simply with the bash substring modifier:

```bash
LO1=${LASTOCTET:0:1}
LO2=${LASTOCTET:1:2}
LO3=${LASTOCTET:2:3}
```

The syntax is actually `startoffset:length`, not `startoffset:endoffset`.

So I thought I'd fix it. I then realised: how do I represent zero blinks unambiguously? Taking some inspiration from morse code, I decided to encode it as a solid i.e. a 1-second dash.

I hope it's ok, but I took the opportunity to DRY up the script a little. The 3 very-similar sections are now just in a loop that iterates over each digit of the octet, without duplication.