### PR TITLE
install curl if it's missing

### DIFF
--- a/payloads/library/recon/Telegram-Nmap-to-Telegram/payload.sh
+++ b/payloads/library/recon/Telegram-Nmap-to-Telegram/payload.sh
@@ -62,6 +62,13 @@ function setup() {
 	# Create tmp scan directory
 	mkdir -p $SCAN_DIR &> /dev/null
 
+        # Install curl if it does not exist                       
+        if [ ! -f /usr/bin/curl ]; then                           
+                opkg update >> /root/opkgupdate.log 2>&1          
+                opkg list >> /root/opkglist.log 2>&1              
+                opkg install curl >> /root/opkginstall.log 2>&1     
+        fi
+
 	# Create tmp scan file if it doesn't exist
 	SCAN_FILE=$SCAN_DIR/scan-count
 	if [ ! -f $SCAN_FILE ]; then


### PR DESCRIPTION
if /usr/bin/curl is not present. install it and log the installation and errors to a file for debugging purposes