### PR TITLE
Fixing subnet confusion

### DIFF
--- a/payloads/library/recon/Sample-Nmap-Payload/payload.sh
+++ b/payloads/library/recon/Sample-Nmap-Payload/payload.sh
@@ -27,7 +27,7 @@ COUNT=$(($(ls -l $LOOT_DIR/*.txt | wc -l)+1))
 NETMODE DHCP_CLIENT
 SERIAL_WRITE [*] Waiting for IP from DHCP
 while [ -z "$SUBNET" ]; do
-  sleep 1 && SUBNET=$(ip addr | grep -i eth0 | grep -i inet | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}[\/]{1}[0-9]{1,2}" | sed 's/\.[0-9]*\//\.0\//')
+  sleep 1 && SUBNET=$(ip addr | grep -i eth0 | grep -i inet | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}[\/]{1}[0-9]{1,2}")
 done
 echo "Recieved IP address from DHCP" >> /tmp/payload-debug.log
 


### PR DESCRIPTION
Setting the last octet to 0 will actually break things depending on the subnet. In case we are in e.g. a /25 network with IP 10.100.100.200 the script will still spit out 10.100.100.0/25 as the network address, which is actually wrong as it should be 10.100.100.128/25. No need to calculate the subnet though as nmap will happily accept the ip in cidr notation to scan the whole subnet.