### PR TITLE
Fixed issue that caused default SSH key path to fail when using SSH key setup

### DIFF
--- a/sharkjack.sh
+++ b/sharkjack.sh
@@ -312,7 +312,7 @@ function setup_shark(){
     [[ -e $SSHKEYPATH ]] && printf "\n%s\n" "[!] $SSHKEYPATH does not exist" && sleep 2 && main_menu
   fi
   if [[ -z $SSHKEYPATH ]]; then
-    ssh-copy-id -i root@172.16.24.1
+    ssh-copy-id "root@172.16.24.1"
   else
     ssh-copy-id -i $SSHKEYPATH "root@172.16.42.1"
   fi


### PR DESCRIPTION
When choosing not to enter an SSH key path manually (therefore using the default path), the usage of the -i option without any specified path in the ssh-copy-id command was causing "root@172.16.24.1" to be interpreted as the path. Removal of the -i option allows for the default path to be used successfully when going through ssh key setup.